### PR TITLE
Fix broken `as` prop for component

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@restar-inc/re-i18n",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.29.0",

--- a/example/src/app/components/Main/Main.vue
+++ b/example/src/app/components/Main/Main.vue
@@ -82,9 +82,23 @@ const STATIC_MESSAGE_4 = {
             {{ t("三番") }}
           </div>
         </ReI18n>
+
+        <h3>With `as(tag)` property but defined as first prop</h3>
+        <ReI18n as="div" msg="赤い：{0}, 緑：{1}, 青い：{2}" class="flex gap-2 flex-wrap items-center p-4">
+          <div class="bg-blue-400 w-10 h-10 rounded-full text-xs flex items-center justify-center">
+            {{ t("三番") }}
+          </div>
+          <div class="bg-green-400 w-10 h-10 rounded-full text-xs flex items-center justify-center">
+            {{ t("二番") }}
+          </div>
+          <div class="bg-red-400 w-10 h-10 rounded-full text-xs flex items-center justify-center">
+            {{ t("一番") }}
+          </div>
+        </ReI18n>
+
       </div>
     </section>
-    
+
     <section class="flex flex-col gap-2">
       <h2 class="text-xl">Component Example</h2>
       <HelloWorld :title="t('こんにちは世界')" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@restar-inc/re-i18n",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@restar-inc/re-i18n",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "dependencies": {
                 "@babel/core": "^7.29.0",
                 "@babel/plugin-proposal-decorators": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@restar-inc/re-i18n",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "A tool to manage i18n by extracting keys from source code and generating locale files",
     "type": "module",
     "main": "lib/index.js",

--- a/src/parser/traverseFile.ts
+++ b/src/parser/traverseFile.ts
@@ -1,5 +1,5 @@
 import { parse as babelParse, traverse as babelTraverse } from "@babel/core";
-import type { StringLiteral } from "@babel/types";
+import type { Identifier, ObjectProperty, StringLiteral } from "@babel/types";
 import {
   isCallExpression,
   isIdentifier,
@@ -133,15 +133,19 @@ export function traverseFile(params: I18nTraverseFileParams) {
         const arg1 = node.arguments[0];
         const arg2 = node.arguments[1];
         if (isIdentifier(arg1) && arg1.name === funcNameVDOM && isObjectExpression(arg2)) {
-          const prop = arg2.properties[0];
+          const msgProp = arg2.properties.find(
+            (prop): prop is ObjectProperty & { key: Identifier } & { value: StringLiteral } => {
+              return (
+                isObjectProperty(prop) &&
+                isIdentifier(prop.key) &&
+                isStringLiteral(prop.value) &&
+                prop.key.name === "msg"
+              );
+            }
+          );
 
-          if (
-            isObjectProperty(prop) &&
-            isIdentifier(prop.key) &&
-            isStringLiteral(prop.value) &&
-            prop.key.name === "msg"
-          ) {
-            params.onEnter(prop.value);
+          if (msgProp != null) {
+            params.onEnter(msgProp.value);
           }
         }
       }


### PR DESCRIPTION
## Overview

`as` prop only works when it's defined as first prop, otherwise, it gets ignored by re-i18n.

This is due to the hardcoded `properties[0]` access instead of finding the `msg` prop during parsing.


### TODO

- [x] bump minor version
  - [x] be sure to update example package-lock
- [x] publish in npm